### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # nokia-iot-connector
 Nokia IMPACT and IBM Watson connector
 
-[![Deploy To Bluemix](https://bluemix.net/deploy/button.png)](https://hub.jazz.net/deploy/index.html?repository=https://github.com/pooja-acharya/nokia-iot-connector.git)
+[![Deploy To Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/pooja-acharya/nokia-iot-connector.git)


### PR DESCRIPTION
The `hub.jazz.net/deploy` link will stop working in a few months. This pull request updates the link to `bluemix.net/deploy`.